### PR TITLE
Fix post-auth redirect flows across user journeys

### DIFF
--- a/app/src/routes/routes.js
+++ b/app/src/routes/routes.js
@@ -17,6 +17,7 @@ router.use(limiter);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const templateDir = path.resolve(__dirname, '..', 'templates');
+const DEFAULT_POST_AUTH_REDIRECT = '/app';
 
 router.get('/', (req, res) => {
   try {
@@ -55,19 +56,18 @@ router.get('/login', redirectIfAuthenticated, (req, res) => {
 });
 
 router.post('/login/password', redirectIfAuthenticated, (req, res, next) => {
-  passport.authenticate('local', (err, user, info) => {
+  passport.authenticate('local', (err, user) => {
     if (err) {
       return next(err);
     }
     if (!user) {
       return res.redirect('/login?error=invalid_credentials');
     }
+    const redirectTo = consumePostAuthRedirect(req);
     return req.logIn(user, (loginError) => {
       if (loginError) {
         return next(loginError);
       }
-      const redirectTo = req.session.returnTo || '/app';
-      delete req.session.returnTo;
       return res.redirect(redirectTo);
     });
   })(req, res, next);
@@ -79,9 +79,11 @@ router.get('/auth/google',
 
 router.get('/auth/google/callback',
   passport.authenticate('google', {
-    successRedirect: '/app',
     failureRedirect: '/login?error=google_auth_failed'
-  })
+  }),
+  (req, res) => {
+    res.redirect(consumePostAuthRedirect(req));
+  }
 );
 
 router.get('/auth/github',
@@ -90,9 +92,11 @@ router.get('/auth/github',
 
 router.get('/auth/github/callback',
   passport.authenticate('github', {
-    successRedirect: '/app',
     failureRedirect: '/login?error=github_auth_failed'
-  })
+  }),
+  (req, res) => {
+    res.redirect(consumePostAuthRedirect(req));
+  }
 );
 
 router.get('/signup', redirectIfAuthenticated, (req, res) => {
@@ -118,11 +122,12 @@ router.post('/signup', redirectIfAuthenticated, async (req, res) => {
 
   try {
     const user = await createUser(username, password);
+    const redirectTo = consumePostAuthRedirect(req);
     return req.logIn(user, (err) => {
       if (err) {
         return res.redirect('/login?error=login_failed');
       }
-      return res.redirect('/app');
+      return res.redirect(redirectTo);
     });
   } catch (error) {
     if (error.code === 'USERNAME_EXISTS') {
@@ -153,15 +158,41 @@ function ensureAuthenticated(req, res, next) {
   if (req.isAuthenticated()) {
     return next();
   }
-  req.session.returnTo = req.originalUrl;
+  req.session.returnTo = sanitizeReturnTo(req.originalUrl);
   return res.redirect('/login?auth=required');
 }
 
 function redirectIfAuthenticated(req, res, next) {
   if (req.isAuthenticated()) {
-    return res.redirect('/app');
+    return res.redirect(DEFAULT_POST_AUTH_REDIRECT);
   }
   return next();
+}
+
+function sanitizeReturnTo(returnToCandidate) {
+  if (!returnToCandidate || typeof returnToCandidate !== 'string') {
+    return null;
+  }
+
+  if (!returnToCandidate.startsWith('/')) {
+    return null;
+  }
+
+  if (returnToCandidate.startsWith('//')) {
+    return null;
+  }
+
+  if (returnToCandidate.startsWith('/auth/')) {
+    return DEFAULT_POST_AUTH_REDIRECT;
+  }
+
+  return returnToCandidate;
+}
+
+function consumePostAuthRedirect(req) {
+  const safeReturnTo = sanitizeReturnTo(req.session.returnTo);
+  delete req.session.returnTo;
+  return safeReturnTo || DEFAULT_POST_AUTH_REDIRECT;
 }
 
 router.get('/about', (req, res) => {

--- a/app/test/auth-flow.test.js
+++ b/app/test/auth-flow.test.js
@@ -20,6 +20,11 @@ async function loadApp(envOverrides = {}) {
   }
 }
 
+function getSessionCookie(response) {
+  const cookieHeader = response.headers.get('set-cookie') ?? '';
+  return cookieHeader.split(';')[0];
+}
+
 test('authenticated users are redirected away from login and signup pages', async () => {
   const app = await loadApp();
   const server = app.listen(0);
@@ -41,8 +46,7 @@ test('authenticated users are redirected away from login and signup pages', asyn
     assert.equal(signupResponse.status, 302);
     assert.equal(signupResponse.headers.get('location'), '/app');
 
-    const cookieHeader = signupResponse.headers.get('set-cookie') ?? '';
-    const sessionCookie = cookieHeader.split(';')[0];
+    const sessionCookie = getSessionCookie(signupResponse);
 
     assert.match(sessionCookie, /^connect\.sid=/);
 
@@ -90,6 +94,106 @@ test('authenticated users are redirected away from login and signup pages', asyn
 
     assert.equal(signupPostResponse.status, 302);
     assert.equal(signupPostResponse.headers.get('location'), '/app');
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('protected route redirects back to original path after signup', async () => {
+  const app = await loadApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve) => server.once('listening', resolve));
+    const { port } = server.address();
+
+    const protectedResponse = await fetch(`http://127.0.0.1:${port}/profile?tab=privacy`, {
+      redirect: 'manual',
+    });
+
+    assert.equal(protectedResponse.status, 302);
+    assert.equal(protectedResponse.headers.get('location'), '/login?auth=required');
+
+    const anonymousCookie = getSessionCookie(protectedResponse);
+    assert.match(anonymousCookie, /^connect\.sid=/);
+
+    const username = `signup_return_${Date.now()}`;
+    const signupResponse = await fetch(`http://127.0.0.1:${port}/signup`, {
+      method: 'POST',
+      headers: {
+        cookie: anonymousCookie,
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({ username, password: 'safe-password-123' }),
+      redirect: 'manual',
+    });
+
+    assert.equal(signupResponse.status, 302);
+    assert.equal(signupResponse.headers.get('location'), '/profile?tab=privacy');
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('post-auth return target is consumed once and does not leak to later sessions', async () => {
+  const app = await loadApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve) => server.once('listening', resolve));
+    const { port } = server.address();
+
+    const protectedResponse = await fetch(`http://127.0.0.1:${port}/profile`, {
+      redirect: 'manual',
+    });
+
+    const anonymousCookie = getSessionCookie(protectedResponse);
+    assert.match(anonymousCookie, /^connect\.sid=/);
+
+    const username = `return_once_${Date.now()}`;
+    const signupResponse = await fetch(`http://127.0.0.1:${port}/signup`, {
+      method: 'POST',
+      headers: {
+        cookie: anonymousCookie,
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({ username, password: 'safe-password-123' }),
+      redirect: 'manual',
+    });
+
+    assert.equal(signupResponse.status, 302);
+    assert.equal(signupResponse.headers.get('location'), '/profile');
+
+    const authenticatedCookie = getSessionCookie(signupResponse) || anonymousCookie;
+
+    const logoutResponse = await fetch(`http://127.0.0.1:${port}/logout`, {
+      headers: {
+        cookie: authenticatedCookie,
+      },
+      redirect: 'manual',
+    });
+
+    assert.equal(logoutResponse.status, 302);
+    assert.equal(logoutResponse.headers.get('location'), '/login');
+
+    const postLogoutCookie = getSessionCookie(logoutResponse) || authenticatedCookie;
+
+    const loginResponse = await fetch(`http://127.0.0.1:${port}/login/password`, {
+      method: 'POST',
+      headers: {
+        cookie: postLogoutCookie,
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({ username, password: 'safe-password-123' }),
+      redirect: 'manual',
+    });
+
+    assert.equal(loginResponse.status, 302);
+    assert.equal(loginResponse.headers.get('location'), '/app');
   } finally {
     await new Promise((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));


### PR DESCRIPTION
### Motivation
- Stabilize and secure post-auth redirection across multiple user journeys (password login, signup, Google/GitHub OAuth) so users reliably return to the intended protected page after authenticating.
- Prevent unsafe or malicious redirect targets and redirect loops originating from unvalidated `returnTo` values.
- Add test coverage for real-world flows to prevent regressions in redirect handling.

### Description
- Introduced a centralized consumption helper `consumePostAuthRedirect(req)` and a default target `DEFAULT_POST_AUTH_REDIRECT = '/app'` to ensure redirect state is consumed once and consistently used by password login, signup, and OAuth callbacks (`/login/password`, `/signup`, `/auth/*/callback`).
- Added `sanitizeReturnTo(returnToCandidate)` to validate and reject unsafe return targets (disallow non-paths, `//` absolute host style, and `/auth/*` paths) and applied it when setting `req.session.returnTo` in `ensureAuthenticated`.
- Updated `redirectIfAuthenticated` to use the default redirect constant and replaced ad-hoc redirect logic in several handlers; updated tests and added integration tests that assert returning to protected pages after signup and that `returnTo` is consumed once.
- Modified files: `app/src/routes/routes.js` and `app/test/auth-flow.test.js` (added helpers and new assertions covering signup/return and one-time consumption of return targets).

### Testing
- Ran the full test suite with `npm test --silent`; all tests passed (`9` tests, `0` failures).
- Integration tests specifically exercising the post-auth redirect flows (return-to-protected-page after signup and one-time consumption) were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc163948bc832a88e7441af1e50a11)